### PR TITLE
benchmark on trajectory games

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,11 +1,16 @@
 [deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MixedComplementarityProblems = "6c9e26cb-9263-41b8-a6c6-f4ca104ccdcd"
 PATHSolver = "f5f7c340-0bb3-5c69-969a-41884d311d1b"
 ParametricMCPs = "9b992ff8-05bb-4ea1-b9d2-5ef72d82f7ad"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TrajectoryGamesBase = "ac1ac542-73eb-4349-ae1b-660ab3609574"
+TrajectoryGamesExamples = "ff3fa34c-8d8f-519c-b5bc-31760c52507a"
 
 [sources]
 MixedComplementarityProblems = {path = ".."}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -8,6 +8,13 @@ Currently, this directory provides code to benchmark the `InteriorPoint` solver 
 
 ```julia
 julia> Revise.includet("SolverBenchmarks.jl")
-julia> data = SolverBenchmarks.benchmark()
+julia> data = SolverBenchmarks.benchmark(SolverBenchmarks.TrajectoryGameBenchmark(); num_samples = 25)
+julia> SolverBenchmarks.summary_statistics(data)
+```
+
+If you want to re-run with different kwargs, you may be able to reuse the MCPs and avoid waiting for them to compile:
+
+```julia
+julia> data = SolverBenchmarks.benchmark(SolverBenchmarks.TrajectoryGameBenchmark(); num_samples = 250, data.ip_mcp, data.path_mcp)
 julia> SolverBenchmarks.summary_statistics(data)
 ```

--- a/benchmark/SolverBenchmarks.jl
+++ b/benchmark/SolverBenchmarks.jl
@@ -2,6 +2,7 @@
 module SolverBenchmarks
 
 using MixedComplementarityProblems: MixedComplementarityProblems
+
 using ParametricMCPs: ParametricMCPs
 using Random: Random
 using Statistics: Statistics

--- a/benchmark/SolverBenchmarks.jl
+++ b/benchmark/SolverBenchmarks.jl
@@ -2,8 +2,8 @@
 module SolverBenchmarks
 
 using MixedComplementarityProblems: MixedComplementarityProblems
-
 using ParametricMCPs: ParametricMCPs
+using BlockArrays: BlockArrays, mortar
 using Random: Random
 using Statistics: Statistics
 using Distributions: Distributions

--- a/benchmark/SolverBenchmarks.jl
+++ b/benchmark/SolverBenchmarks.jl
@@ -15,7 +15,7 @@ struct QuadraticProgramBenchmark <: BenchmarkType end
 struct TrajectoryGameBenchmark <: BenchmarkType end
 
 include("quadratic_program_benchmark.jl")
-#include("trajectory_game_benchmark.jl")
+include("trajectory_game_benchmark.jl")
 include("path.jl")
 
 end # module SolverBenchmarks

--- a/benchmark/SolverBenchmarks.jl
+++ b/benchmark/SolverBenchmarks.jl
@@ -7,6 +7,7 @@ using ParametricMCPs: ParametricMCPs
 using Random: Random
 using Statistics: Statistics
 using Distributions: Distributions
+using LazySets: LazySets
 using PATHSolver: PATHSolver
 using ProgressMeter: @showprogress
 

--- a/benchmark/SolverBenchmarks.jl
+++ b/benchmark/SolverBenchmarks.jl
@@ -9,6 +9,12 @@ using Distributions: Distributions
 using PATHSolver: PATHSolver
 using ProgressMeter: @showprogress
 
+abstract type BenchmarkType end
+struct QuadraticProgramBenchmark <: BenchmarkType end
+struct TrajectoryGameBenchmark <: BenchmarkType end
+
+include("quadratic_program_benchmark.jl")
+#include("trajectory_game_benchmark.jl")
 include("path.jl")
 
 end # module SolverBenchmarks

--- a/benchmark/path.jl
+++ b/benchmark/path.jl
@@ -7,12 +7,11 @@ function benchmark(
     path_mcp = nothing,
     ip_kwargs = (; tol = 1e-6),
 )
-    rng = Random.MersenneTwister(1)
-
     # Generate problem and random parameters.
     @info "Generating random problems..."
     problem = generate_test_problem(benchmark_type; problem_kwargs...)
 
+    rng = Random.MersenneTwister(1)
     θs = map(1:num_samples) do _
         generate_random_parameter(benchmark_type; rng, problem_kwargs...)
     end

--- a/benchmark/path.jl
+++ b/benchmark/path.jl
@@ -20,25 +20,48 @@ function benchmark(
     # Generate corresponding MCPs.
     @info "Generating IP MCP..."
     parameter_dimension = length(first(θs))
-    ip_mcp =
-        !isnothing(ip_mcp) ? ip_mcp :
+    ip_mcp = if !isnothing(ip_mcp)
+        ip_mcp
+    elseif hasproperty(problem, :K)
+        # Generated a callable problem.
         MixedComplementarityProblems.PrimalDualMCP(
-            problem.G,
-            problem.H;
-            problem.unconstrained_dimension,
-            problem.constrained_dimension,
+            problem.K,
+            problem.lower_bounds,
+            problem.upper_bounds;
             parameter_dimension,
         )
+    else
+        # Generated a symbolic problem.
+        MixedComplementarityProblems.PrimalDualMCP(
+            problem.K_symbolic,
+            problem.z_symbolic,
+            problem.θ_symbolic,
+            problem.lower_bounds,
+            problem.upper_bounds,
+        )
+    end
 
     @info "Generating PATH MCP..."
-    path_mcp =
-        !isnothing(path_mcp) ? path_mcp :
+    path_mcp = if !isnothing(path_mcp)
+        path_mcp
+    elseif hasproperty(problem, :K)
+        # Generated a callable problem.
         ParametricMCPs.ParametricMCP(
             problem.K,
             problem.lower_bounds,
             problem.upper_bounds,
             parameter_dimension,
         )
+    else
+        # Generated a symbolic problem.
+        ParametricMCPs.ParametricMCP(
+            problem.K_symbolic,
+            problem.z_symbolic,
+            problem.θ_symbolic,
+            problem.lower_bounds,
+            problem.upper_bounds
+        )
+    end
 
     # Warm up the solvers.
     @info "Warming up IP solver..."

--- a/benchmark/quadratic_program_benchmark.jl
+++ b/benchmark/quadratic_program_benchmark.jl
@@ -44,15 +44,7 @@ function generate_test_problem(
     lower_bounds = [fill(-Inf, num_primals); fill(0, num_inequalities)]
     upper_bounds = fill(Inf, num_primals + num_inequalities)
 
-    (;
-        G,
-        H,
-        K,
-        unconstrained_dimension,
-        constrained_dimension,
-        lower_bounds,
-        upper_bounds,
-    )
+    (; K, lower_bounds, upper_bounds)
 end
 
 "Generate a random parameter vector Θ corresponding to a convex QP."

--- a/benchmark/quadratic_program_benchmark.jl
+++ b/benchmark/quadratic_program_benchmark.jl
@@ -1,0 +1,98 @@
+""" Generate a random (convex) quadratic problem of the form
+                               min_x 0.5 xᵀ M x - ϕᵀ x
+                               s.t.  Ax - b ≥ 0.
+
+NOTE: the problem may not be feasible!
+"""
+function generate_test_problem(
+    ::QuadraticProgramBenchmark;
+    num_primals = 100,
+    num_inequalities = 100,
+)
+    G(x, y; θ) =
+        let
+            (; M, A, ϕ) = unpack_parameters(
+                QuadraticProgramBenchmark(),
+                θ;
+                num_primals,
+                num_inequalities,
+            )
+            M * x - ϕ - A' * y
+        end
+
+    H(x, y; θ) =
+        let
+            (; A, b) = unpack_parameters(
+                QuadraticProgramBenchmark(),
+                θ;
+                num_primals,
+                num_inequalities,
+            )
+            A * x - b
+        end
+
+    K(z, θ) =
+        let
+            x = z[1:num_primals]
+            y = z[(num_primals + 1):end]
+
+            [G(x, y; θ); H(x, y; θ)]
+        end
+
+    unconstrained_dimension = num_primals
+    constrained_dimension = num_inequalities
+    lower_bounds = [fill(-Inf, num_primals); fill(0, num_inequalities)]
+    upper_bounds = fill(Inf, num_primals + num_inequalities)
+
+    (;
+        G,
+        H,
+        K,
+        unconstrained_dimension,
+        constrained_dimension,
+        lower_bounds,
+        upper_bounds,
+    )
+end
+
+"Generate a random parameter vector Θ corresponding to a convex QP."
+function generate_random_parameter(
+    ::QuadraticProgramBenchmark;
+    rng,
+    num_primals = 100,
+    num_inequalities = 100,
+    sparsity_rate = 0.9,
+)
+    bernoulli = Distributions.Bernoulli(1 - sparsity_rate)
+
+    M = let
+        P =
+            randn(rng, num_primals, num_primals) .*
+            rand(rng, bernoulli, num_primals, num_primals)
+        P' * P
+    end
+
+    A =
+        randn(rng, num_inequalities, num_primals) .*
+        rand(rng, bernoulli, num_inequalities, num_primals)
+    b = randn(rng, num_inequalities)
+    ϕ = randn(rng, num_primals)
+
+    [reshape(M, length(M)); reshape(A, length(A)); b; ϕ]
+end
+
+"Unpack a parameter vector θ into the components of a convex QP."
+function unpack_parameters(::QuadraticProgramBenchmark, θ; num_primals, num_inequalities)
+    M = reshape(θ[1:(num_primals^2)], num_primals, num_primals)
+    A = reshape(
+        θ[(num_primals^2 + 1):(num_primals^2 + num_inequalities * num_primals)],
+        num_inequalities,
+        num_primals,
+    )
+
+    b =
+        θ[(num_primals^2 + num_inequalities * num_primals + 1):(num_primals^2 + num_inequalities * (num_primals + 1))]
+    ϕ = θ[(num_primals^2 + num_inequalities * (num_primals + 1) + 1):end]
+
+    (; M, A, b, ϕ)
+end

--- a/benchmark/trajectory_game_benchmark.jl
+++ b/benchmark/trajectory_game_benchmark.jl
@@ -73,10 +73,15 @@ function generate_random_parameter(
     )
 
     initial_states = mortar([
-        LazySets.sample(environment.set; rng),
-        LazySets.sample(environment.set; rng),
+        [LazySets.sample(environment.set; rng); zeros(2)],
+        [LazySets.sample(environment.set; rng); zeros(2)],
     ])
-    horizontal_references = mortar([rand(rng, lane_centers), rand(rng, lane_centers)])
+    horizontal_references = mortar([[rand(rng, lane_centers)], [rand(rng, lane_centers)]])
 
-    TrajectoryGameBenchmarkUtils.pack_parameters(initial_states, horizontal_references)
+    collect(
+        TrajectoryGameBenchmarkUtils.pack_parameters(
+            initial_states,
+            horizontal_references,
+        ),
+    )
 end

--- a/benchmark/trajectory_game_benchmark.jl
+++ b/benchmark/trajectory_game_benchmark.jl
@@ -1,5 +1,7 @@
 module TrajectoryGameBenchmarkUtils
 
+using MixedComplementarityProblems: MixedComplementarityProblems
+
 using LazySets: LazySets
 using TrajectoryGamesBase:
     TrajectoryGamesBase,
@@ -31,7 +33,32 @@ include("../examples/lane_change.jl")
 end # module TrajectoryGameBenchmarkUtils
 
 "Generate a random trajectory game, based on the `LaneChange` problem in `examples/`."
-function generate_test_problem(::TrajectoryGameBenchmark; horizon = 10)
+function generate_test_problem(
+    ::TrajectoryGameBenchmark;
+    horizon = 10,
+    height = 50,
+    num_lanes = 2,
+    lane_width = 2,
+)
+    (; environment, lane_centers) = TrajectoryGameBenchmarkUtils.setup_road_environment(;
+        num_lanes,
+        lane_width,
+        height,
+    )
+    game = TrajectoryGameBenchmarkUtils.setup_trajectory_game(; environment)
+
+    # Build a game. Each player has a parameter for lane preference. P1 wants to stay
+    # in the left lane, and P2 wants to move from the right to the left lane.
+    lane_preferences = mortar([[lane_centers[1]], [lane_centers[1]]])
+    parametric_game = TrajectoryGameBenchmarkUtils.(;
+        game,
+        horizon,
+        params_per_player = 1,
+    )
+
+    # Parse problem components.
+
+
     (;
         G,
         H,
@@ -45,7 +72,7 @@ end
 
 "Generate a random parameter vector Θ corresponding to a convex QP."
 function generate_random_parameter(
-    ::QuadraticProgramBenchmark;
+    ::TrajectoryGameBenchmark;
     rng,
     num_primals,
     num_inequalities,

--- a/benchmark/trajectory_game_benchmark.jl
+++ b/benchmark/trajectory_game_benchmark.jl
@@ -1,6 +1,37 @@
+module TrajectoryGameBenchmarkUtils
+
+using LazySets: LazySets
+using TrajectoryGamesBase:
+    TrajectoryGamesBase,
+    PolygonEnvironment,
+    ProductDynamics,
+    TimeSeparableTrajectoryGameCost,
+    TrajectoryGame,
+    GeneralSumCostStructure,
+    num_players,
+    time_invariant_linear_dynamics,
+    unstack_trajectory,
+    stack_trajectories,
+    state_dim,
+    control_dim,
+    state_bounds,
+    control_bounds,
+    OpenLoopStrategy,
+    JointStrategy,
+    RecedingHorizonStrategy,
+    rollout
+using TrajectoryGamesExamples: planar_double_integrator, animate_sim_steps
+using BlockArrays: mortar, blocks, BlockArray, Block
+using LinearAlgebra: norm_sqr, norm
+using ProgressMeter: ProgressMeter
+
+include("../examples/utils.jl")
+include("../examples/lane_change.jl")
+
+end # module TrajectoryGameBenchmarkUtils
+
 "Generate a random trajectory game, based on the `LaneChange` problem in `examples/`."
 function generate_test_problem(::TrajectoryGameBenchmark; horizon = 10)
-
     (;
         G,
         H,

--- a/benchmark/trajectory_game_benchmark.jl
+++ b/benchmark/trajectory_game_benchmark.jl
@@ -1,0 +1,55 @@
+"Generate a random trajectory game, based on the `LaneChange` problem in `examples/`."
+function generate_test_problem(::TrajectoryGameBenchmark; horizon = 10)
+
+    (;
+        G,
+        H,
+        K,
+        unconstrained_dimension,
+        constrained_dimension,
+        lower_bounds,
+        upper_bounds,
+    )
+end
+
+"Generate a random parameter vector Θ corresponding to a convex QP."
+function generate_random_parameter(
+    ::QuadraticProgramBenchmark;
+    rng,
+    num_primals,
+    num_inequalities,
+    sparsity_rate,
+)
+    bernoulli = Distributions.Bernoulli(1 - sparsity_rate)
+
+    M = let
+        P =
+            randn(rng, num_primals, num_primals) .*
+            rand(rng, bernoulli, num_primals, num_primals)
+        P' * P
+    end
+
+    A =
+        randn(rng, num_inequalities, num_primals) .*
+        rand(rng, bernoulli, num_inequalities, num_primals)
+    b = randn(rng, num_inequalities)
+    ϕ = randn(rng, num_primals)
+
+    [reshape(M, length(M)); reshape(A, length(A)); b; ϕ]
+end
+
+"Unpack a parameter vector θ into the components of a convex QP."
+function unpack_parameters(::QuadraticProgramBenchmark, θ; num_primals, num_inequalities)
+    M = reshape(θ[1:(num_primals^2)], num_primals, num_primals)
+    A = reshape(
+        θ[(num_primals^2 + 1):(num_primals^2 + num_inequalities * num_primals)],
+        num_inequalities,
+        num_primals,
+    )
+
+    b =
+        θ[(num_primals^2 + num_inequalities * num_primals + 1):(num_primals^2 + num_inequalities * (num_primals + 1))]
+    ϕ = θ[(num_primals^2 + num_inequalities * (num_primals + 1) + 1):end]
+
+    (; M, A, b, ϕ)
+end

--- a/examples/TrajectoryExamples.jl
+++ b/examples/TrajectoryExamples.jl
@@ -44,6 +44,21 @@ using Makie: Makie
 using LinearAlgebra: norm_sqr, norm
 using ProgressMeter: ProgressMeter
 
+"Visualize a strategy `γ` on a makie canvas using the base color `color`."
+function TrajectoryGamesBase.visualize!(
+    canvas,
+    γ::Makie.Observable{<:OpenLoopStrategy};
+    color = :black,
+    weight_offset = 0.0,
+)
+    Makie.series!(canvas, γ; color = [(color, min(1.0, 0.9 + weight_offset))])
+end
+
+function Makie.convert_arguments(::Type{<:Makie.Series}, γ::OpenLoopStrategy)
+    traj_points = map(s -> Makie.Point2f(s[1:2]), γ.xs)
+    ([traj_points],)
+end
+
 include("utils.jl")
 include("lane_change.jl")
 

--- a/examples/utils.jl
+++ b/examples/utils.jl
@@ -230,18 +230,3 @@ function (strategy::WarmStartRecedingHorizonStrategy)(state, time)
 
     strategy.receding_horizon_strategy(state, time_along_plan)
 end
-
-"Visualize a strategy `γ` on a makie canvas using the base color `color`."
-function TrajectoryGamesBase.visualize!(
-    canvas,
-    γ::Makie.Observable{<:OpenLoopStrategy};
-    color = :black,
-    weight_offset = 0.0,
-)
-    Makie.series!(canvas, γ; color = [(color, min(1.0, 0.9 + weight_offset))])
-end
-
-function Makie.convert_arguments(::Type{<:Makie.Series}, γ::OpenLoopStrategy)
-    traj_points = map(s -> Makie.Point2f(s[1:2]), γ.xs)
-    ([traj_points],)
-end


### PR DESCRIPTION
- [x] factor out benchmarking code to work for different types of problems (i.e., adding `BenchmarkType` abstraction)
- [x] introduce `TrajectoryGameBenchmark` modeled on `LaneChange` in `examples/`