### PR TITLE
More flexible regularization of Newton step

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -9,6 +9,7 @@ ParametricMCPs = "9b992ff8-05bb-4ea1-b9d2-5ef72d82f7ad"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 TrajectoryGamesBase = "ac1ac542-73eb-4349-ae1b-660ab3609574"
 TrajectoryGamesExamples = "ff3fa34c-8d8f-519c-b5bc-31760c52507a"
 

--- a/benchmark/SolverBenchmarks.jl
+++ b/benchmark/SolverBenchmarks.jl
@@ -10,6 +10,7 @@ using Distributions: Distributions
 using LazySets: LazySets
 using PATHSolver: PATHSolver
 using ProgressMeter: @showprogress
+using Symbolics: Symbolics
 
 abstract type BenchmarkType end
 struct QuadraticProgramBenchmark <: BenchmarkType end

--- a/benchmark/path.jl
+++ b/benchmark/path.jl
@@ -36,7 +36,8 @@ function benchmark(
             problem.z_symbolic,
             problem.θ_symbolic,
             problem.lower_bounds,
-            problem.upper_bounds,
+            problem.upper_bounds;
+            η_symbolic = hasproperty(problem, :η_symbolic) ? problem.η_symbolic : nothing,
         )
     end
 
@@ -46,19 +47,28 @@ function benchmark(
     elseif hasproperty(problem, :K)
         # Generated a callable problem.
         ParametricMCPs.ParametricMCP(
-            problem.K,
+            (z, θ) -> problem.K(z; θ),
             problem.lower_bounds,
             problem.upper_bounds,
             parameter_dimension,
         )
     else
         # Generated a symbolic problem.
+        K_symbolic =
+            !hasproperty(problem, :η_symbolic) ? problem.K_symbolic :
+            Vector{Symbolics.Num}(
+                Symbolics.substitute(
+                    problem.K_symbolic,
+                    Dict([problem.η_symbolic => 0.0]),
+                ),
+            )
+
         ParametricMCPs.ParametricMCP(
-            problem.K_symbolic,
+            K_symbolic,
             problem.z_symbolic,
             problem.θ_symbolic,
             problem.lower_bounds,
-            problem.upper_bounds
+            problem.upper_bounds;
         )
     end
 

--- a/benchmark/quadratic_program_benchmark.jl
+++ b/benchmark/quadratic_program_benchmark.jl
@@ -31,7 +31,7 @@ function generate_test_problem(
             A * x - b
         end
 
-    K(z, θ) =
+    K(z; θ) =
         let
             x = z[1:num_primals]
             y = z[(num_primals + 1):end]

--- a/examples/utils.jl
+++ b/examples/utils.jl
@@ -59,6 +59,7 @@ function build_parametric_game(;
         K_symbolic,
         z_symbolic,
         θ_symbolic,
+        η_symbolic,
         lower_bounds,
         upper_bounds,
         dims,
@@ -72,7 +73,8 @@ function build_parametric_game(;
         z_symbolic,
         θ_symbolic,
         lower_bounds,
-        upper_bounds,
+        upper_bounds;
+        η_symbolic,
     )
     MixedComplementarityProblems.ParametricGame(
         problems,

--- a/src/mcp.jl
+++ b/src/mcp.jl
@@ -12,7 +12,7 @@ hand side of this system of equations. Here, `η` is an optional nonnegative
 regularization parameter defined by "internally-regularized" problems.
 """
 struct PrimalDualMCP{T1,T2,T3}
-    "A callable `F!(result, x, y, s; θ, ϵ, [η])` to the KKT error in-place."
+    "A callable `F!(result, x, y, s; θ, ϵ, [η])` to compute the KKT error in-place."
     F!::T1
     "A callable `∇F_z!(result, x, y, s; θ, ϵ, [η])` to compute ∇F wrt z in-place."
     ∇F_z!::T2


### PR DESCRIPTION
Adds an additional kwarg in the solver which allows the user to specify how the Newton step computation should be regularized. Currently supports three options:
- `:none` (no regularization)
- `:identity` (adds scaled identity to the KKT Jacobian)
- `:internal` (assumes that the Symbolics-generated KKT Jacobian accepts a regularization parameter directly)

Also adds an example of `:internal` regularization in `game.jl` where we add a scaled identity only to the blocks of the KKT Jacobian that correspond to the Hessian of each player's Lagrangian wrt its decision variable.

Also adds some minimal logic to adjust regularization strength depending upon success/failure of inner loop solves. 